### PR TITLE
Reworked the case logic to add an option to unset the profile for ...

### DIFF
--- a/awsprofile.sh
+++ b/awsprofile.sh
@@ -2,7 +2,7 @@
 
 AWS_PROFILES=$(cat ~/.aws/credentials | grep '\[*\]' | cut -d "[" -f2 | cut -d "]" -f1)
 
-printf "\nChoose your AWS profile:\n\n"
+printf "\nChoose your AWS profile:\n\n0)Unset/clear all profiles\n"
 
 COUNT=0
 
@@ -16,9 +16,14 @@ printf "\nSelect profile number and press [ENTER]: "
 read n
 
 case $n in
-  [0-9]*) MY_AWS_PROFILE=$(echo "$AWS_PROFILES" | awk "NR==$n{print}");;
+  [1-9]*) MY_AWS_PROFILE=$(echo "$AWS_PROFILES" | awk "NR==$n{print}")
+	  export AWS_PROFILE=$MY_AWS_PROFILE
+          printf "\nThe AWS profile ${AWS_PROFILE} has been set.\n\n"
+  ;;
+  0)
+          unset AWS_PROFILE
+          export -p | grep AWS #just to double check
+          printf "\nThe AWS profile has been cleared.\n\n"
+  ;;
 esac
 
-export AWS_PROFILE=$MY_AWS_PROFILE
-
-printf "\nThe AWS profile ${AWS_PROFILE} has been set.\n\n"


### PR DESCRIPTION
…security. We normally don't want to leave the profile set to, for example, a production account, and then accidentally run your commands/code against that.